### PR TITLE
Better error messages if FASTA/FASTQ format is incorrect

### DIFF
--- a/include/sbwt/SeqIO.hh
+++ b/include/sbwt/SeqIO.hh
@@ -121,9 +121,9 @@ public:
         
         char c = 0; stream->get(&c);
         if(mode == FASTA && c != '>')
-            throw runtime_error("ERROR: FASTA file does not start with '>'");
+            throw runtime_error("ERROR: FASTA file " + filename + " does not start with '>'");
         if(mode == FASTQ && c != '@')
-            throw runtime_error("ERROR: FASTQ file does not start with '@'");
+            throw runtime_error("ERROR: FASTQ file " + filename + " does not start with '@'");
 
         // This leaves the input stream pointer after the first character, but
         // get_next_read_to_buffer is written such that it's ok.


### PR DESCRIPTION
Add the offending filename to the exception thrown from the SeqIO::Reader constructor if the format does not match what's expected of FASTA or FASTQ files. This helps to find the offending file(s).

Example output from new error message:
```
Runtime error: ERROR: FASTA file GCA_902158765.1_25426_7_21_genomic.fna.gz does not start with '>'
```

Example from old error message:
```
Runtime error: ERROR: FASTA file does not start with '>'
```